### PR TITLE
feat: add event dispatching for upload actions

### DIFF
--- a/src/Events/MultipartUploadCompleted.php
+++ b/src/Events/MultipartUploadCompleted.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace MrEduar\S3M\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MultipartUploadCompleted
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public string $bucket,
+        public string $key,
+        public string $uploadId,
+        public string $url,
+    ) {}
+}

--- a/src/Events/MultipartUploadCreated.php
+++ b/src/Events/MultipartUploadCreated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace MrEduar\S3M\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MultipartUploadCreated
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public string $uuid,
+        public string $bucket,
+        public string $key,
+        public string $uploadId,
+    ) {}
+}

--- a/tests/Isolated/S3MultipartControllerTest.php
+++ b/tests/Isolated/S3MultipartControllerTest.php
@@ -156,6 +156,8 @@ it('can complete multipart upload', function () {
 
     $mock->shouldReceive('completeMultipartUpload')->once()->andReturn(new \Aws\Result([
         'Location' => 'https://example.com',
+        'Bucket' => 'test-bucket',
+        'Key' => $key = Str::uuid()->toString(),
     ]));
 
     $this->app->instance(Aws\S3\S3Client::class, $mock);
@@ -167,7 +169,8 @@ it('can complete multipart upload', function () {
             ['ETag' => Str::random(), 'PartNumber' => 1],
             ['ETag' => Str::random(), 'PartNumber' => 2],
         ],
-    ])->assertOk()
+    ])
+        ->assertOk()
         ->assertJson(fn (AssertableJson $json) => $json
             ->where('key', $key)
             ->where('url', 'https://example.com')


### PR DESCRIPTION
This PR introduces event dispatching for key upload actions, including `MultipartUploadCreated` and `MultipartUploadCompleted`.

## Key Changes
- Added Laravel events for `MultipartUploadCreated` and `MultipartUploadCompleted`.
- These events allow developers to create custom listeners for tracking multipart uploads and implementing additional functionality, such as logging or monitoring.

## Benefits
- Enhances the flexibility and extensibility of the package.
- Enables seamless integration with application-specific features without modifying the core package.

## Notes
- This is primarily an enhancement to support better developer customization.
- Documentation updates may be required to guide users on utilizing the new events.

Looking forward to feedback or suggestions for improvement!