### PR TITLE
Fix controller tests route and status assertions

### DIFF
--- a/tests/Isolated/S3MultipartControllerTest.php
+++ b/tests/Isolated/S3MultipartControllerTest.php
@@ -155,9 +155,11 @@ it('signing urls catched exceptions when upload_id is invalid', function () {
         'part_number' => 1,
         'upload_id' => Str::random(),
         'content_type' => 'image/jpeg',
-    ]))->assertJson([
-        'error' => 'Upload not found',
-    ]);
+    ]))
+        ->assertStatus(500)
+        ->assertJson([
+            'error' => 'Upload not found',
+        ]);
 });
 
 it('can complete multipart upload', function () {
@@ -206,6 +208,7 @@ it('complete multipart catched exceptions', function () {
             ['ETag' => Str::random(), 'PartNumber' => 2],
         ],
     ])
+        ->assertStatus(500)
         ->assertJson([
             'error' => 'Upload not found',
         ]);
@@ -219,7 +222,7 @@ it('throw an exception when none of the required env variables are set', functio
 
     withoutExceptionHandling();
 
-    postJson(route('storage.create.multipart'));
+    postJson(route('s3m.create-multipart'));
 })->throws(InvalidArgumentException::class);
 
 it('cannot change visibility if config is false', function () {


### PR DESCRIPTION
## Summary
- ensure signing URLs and complete multipart tests expect 500 status
- adjust route name for missing-env-vars exception test
