### PR TITLE
ci: unblock prefer-lowest matrix from Composer advisory check

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -53,6 +53,13 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
+      - name: Allow advisory-affected versions during matrix testing
+        # The prefer-lowest matrix pins the oldest in-range laravel/framework, which
+        # Composer 2.9+ refuses to install once those versions carry security advisories.
+        # These are ephemeral CI installs for compatibility testing only, never shipped,
+        # so disable advisory blocking here (it stays enabled for real composer updates).
+        run: composer config policy.advisories.block false
+
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.os == 'windows-latest' && '^^^' || '' }}${{ matrix.carbon }}" --no-interaction --no-update


### PR DESCRIPTION
## Problem

The `run-tests` workflow started failing on almost every matrix combination, at the **Install dependencies** step (not in the tests themselves):

```
Your requirements could not be resolved to an installable set of packages.
  - Root composer.json requires laravel/framework 11.*, found laravel/framework[v11.0.0, ..., v11.54.0]
    but these were not loaded, because they are affected by security advisories
    ("PKSA-mdq4-51ck-6kdq", ...). To turn the feature off entirely, you can set
    "policy.advisories.block" to false.
```

**Cause:** Composer 2.9+ blocks installing dependency versions affected by security advisories by default. The `prefer-lowest` matrix pins the oldest in-range `laravel/framework`, which is now flagged by recent Laravel advisories, so resolution fails. This breaks every PHP push and is unrelated to any package change.

Note: `laravel/framework` is **not** a runtime dependency of this package — it is only pulled in by `orchestra/testbench` for tests. Production dependencies are `illuminate/contracts`, `aws/aws-sdk-php`, and `spatie/laravel-package-tools`.

## Fix

Add a step that disables advisory blocking **in the test job only**. These are ephemeral CI installs used to verify compatibility against the lowest supported version floor; they are never shipped. Advisory protection stays enabled for real `composer update` runs by maintainers and contributors (`composer.json` is untouched).

## Local verification (Composer 2.10.1)

- Reproduced the block by forcing `laravel/framework:11.*` + `testbench:9.*` with `--prefer-lowest`.
- With `composer config policy.advisories.block false`, resolution succeeds.
- `vendor/bin/pest --ci` → **14 passed (62 assertions)** on `laravel/framework v11.22.0` (prefer-lowest L11).

This PR's matrix confirms the remaining combinations.
