### PR TITLE
feat!: support Laravel 12|13 on PHP 8.3+, drop Laravel 11 and PHP 8.2 (v3.0.0)

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,16 +24,16 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4, 8.3, 8.2]
-        laravel: [12.*, 11.*]
+        php: [8.4, 8.3]
+        laravel: [13.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.8
           - laravel: 12.*
             testbench: 10.*
             carbon: ^3.8
-          - laravel: 11.*
-            testbench: 9.*
-            carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to `s3m` will be documented in this file.
 
+## v3.0.0 - 2026-06-14
+
+### Breaking
+
+- Dropped Laravel 11 support. The supported range is now Laravel 12 and 13 (`illuminate/contracts: ^12.0|^13.0`).
+
+  Laravel 11 has reached the end of its security-support window and every 11.x release is affected by CVE-2026-48019 (CRLF injection in the default email rule), with no patched 11.x version available. Rather than disable Composer's security-advisory blocking to keep testing against a permanently vulnerable framework, support is dropped. Users on Laravel 11 should upgrade.
+
+- Dropped PHP 8.2 support. Minimum requirement is now PHP 8.3 (`php: ^8.3`). The test toolchain (Pest 4, required for Laravel 13) needs PHP 8.3+, so 8.2 can no longer be exercised in CI. PHP 8.2 users can stay on the 2.x line.
+
+### Added
+
+- Laravel 13 support.
+
+### Changed
+
+- Upgraded the dev/test toolchain for Laravel 13: Pest 3 → 4, `pest-plugin-laravel` 3 → 4, `pest-plugin-arch` 3 → 4, `larastan` → ^3.10, `collision` → ^8.8, and `orchestra/testbench` now allows ^10.0|^11.0.
+
+### CI
+
+- The test matrix now targets Laravel 12 and 13 on PHP 8.3 and 8.4. `prefer-lowest` resolves to the first non-advisory release of each line (12.60.0 / 13.10.0), so Composer's advisory blocking stays enabled — no bypass needed.
+
 ## v2.0.2 - 2026-06-14
 
 ### Security

--- a/composer.json
+++ b/composer.json
@@ -16,20 +16,20 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "aws/aws-sdk-php": "^3.316",
-        "illuminate/contracts": "^11.0|^12.0",
+        "illuminate/contracts": "^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
-        "larastan/larastan": "^3.0",
+        "larastan/larastan": "^3.10",
         "laravel/pint": "^1.14",
         "mockery/mockery": "^1.6",
-        "nunomaduro/collision": "^8.1.1",
-        "orchestra/testbench": "^10.0",
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-plugin-arch": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.0",
+        "nunomaduro/collision": "^8.8",
+        "orchestra/testbench": "^10.0|^11.0",
+        "pestphp/pest": "^4.4",
+        "pestphp/pest-plugin-arch": "^4.0",
+        "pestphp/pest-plugin-laravel": "^4.1",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0"


### PR DESCRIPTION
## Summary

This is the **v3.0.0** release. It drops Laravel 11 (EOL and permanently vulnerable), adds Laravel 13, and moves the PHP floor to 8.3.

## Breaking changes

- **Drop Laravel 11.** Every 11.x release is affected by CVE-2026-48019 (CRLF injection in the default email rule) with no patched 11.x version, and Laravel 11 is past its security-support window. Keeping it green would have required disabling Composer's security-advisory blocking; dropping support is the clean path. Supported range is now `illuminate/contracts: ^12.0|^13.0`.
- **Drop PHP 8.2.** Adding Laravel 13 requires `pest-plugin-laravel` 4 → Pest 4, which needs PHP 8.3+. PHP 8.2 can no longer run the test/static-analysis pipelines, so the floor moves to `php: ^8.3`. PHP 8.2 / Laravel 11 users can stay on the 2.x line.

## Added

- **Laravel 13 support.** Verified locally: 14 passed (62 assertions) on `laravel/framework` v13.10.0 (prefer-lowest) and v13.15.0 (prefer-stable).

## Changed

- Dev/test toolchain bumped for Laravel 13: Pest 3 → 4, `pest-plugin-laravel` 3 → 4, `pest-plugin-arch` 3 → 4, `larastan` → ^3.10, `collision` → ^8.8, `orchestra/testbench` → ^10.0|^11.0.
- `run-tests` matrix: PHP `[8.4, 8.3]` × Laravel `[13.*, 12.*]` (testbench 11/10).
- `phpstan` workflow: PHP 8.2 → 8.3.

## Why no advisory bypass

With Laravel 11 gone, Composer's advisory blocking stays **enabled**. `prefer-lowest` resolves to the first non-advisory release of each supported line — `12.60.0` and `13.10.0` — so the CI never installs a flagged version and no `policy.advisories.block` override is needed. (Supersedes #24.)

## Local verification (Composer 2.10.1, PHP 8.3)

| Combo | Resolves to | Tests |
|-------|-------------|-------|
| Laravel 12 prefer-lowest | 12.60.0 | 14 passed |
| Laravel 13 prefer-lowest | 13.10.0 | 14 passed |
| Laravel 13 prefer-stable | 13.15.0 | 14 passed |

PHPStan: **No errors** against Laravel 13.15.0. The full matrix on this PR confirms the rest.
